### PR TITLE
2.3.0 split annotation sources

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -66,20 +66,106 @@
       "optional": false
     },
     {
-      "name": "vep_tarball",
-      "label": "vep docker and annotation sources",
-      "help": "tarball containing VEP docker image, plugins and annotation sources",
+      "name": "vep_docker",
+      "label": "VEP docker image",
+      "help": "compressed docker image of VEP",
       "class": "file",
-      "patterns": ["vep*.tar"],
-      "default": {"$dnanexus_link": "file-G5PX9qj433Gjvv1F3Bf6KFqv"},
+      "patterns": ["*docker.tar.gz"],
+      "optional": false,
+      "default": {
+        "$dnanexus_link": "file-G61zff8433Gy2KQX7Q2z150B"
+      },
       "suggestions": [
         {
           "name": "001_Reference",
           "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-          "path": "/assets/vep/vep_v103.1.4"
+          "path": "/assets/vep/vep_docker_v103.1/"
+        }
+      ]
+    },
+    {
+      "name": "vep_plugins",
+      "label": "plugin files for VEP",
+      "help": "Associated plugin files for VEP",
+      "class": "array:file",
+      "optional": false,
+      "default": [
+        {
+          "$dnanexus_link": "file-G61zfvj433GxkQXF414xP1yF"
+        },
+        {
+          "$dnanexus_link": "file-G620928433Gy9p2b27zb8JFV"
         }
       ],
-      "optional": false
+      "suggestions": [
+        {
+          "name": "001_Reference",
+          "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+          "path": "/assets/vep/vep_docker_v103.1/"
+        }
+      ]
+    },
+    {
+      "name": "vep_refs",
+      "label": "reference sources for VEP",
+      "help": "Reference file annotation sources for VEP (not ClinVar etc.)",
+      "class": "array:file",
+      "optional": false,
+      "default": [
+        {
+          "$dnanexus_link": "file-G61y95Q433Gk05zyFKF9kFv2"
+        },
+        {
+          "$dnanexus_link": "file-G61yBV8433GjbVj022PyV3K5"
+        },
+        {
+          "$dnanexus_link": "file-G61yBf0433Gp4BBVGj0jxqvP"
+        },
+        {
+          "$dnanexus_link": "file-G61yF38433GQgP504Px5PZ4G"
+        }
+      ],
+      "suggestions": [
+        {
+          "name": "001_Reference",
+          "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+          "path": "/annotation/b38/vep/"
+        }
+      ]
+    },
+    {
+      "name": "vep_annotation",
+      "label": "annotation sources for VEP",
+      "help": "Reference file annotation sources for VEP and index (ClinVar & CADD)",
+      "class": "array:file",
+      "optional": false,
+      "default": [
+        {
+          "$dnanexus_link": "file-G61xXjj433GzPf7Q45Z7pf2z"
+        },
+        {
+          "$dnanexus_link": "file-G61xXyj433Gz7Bx5P8j7zbGy"
+        },
+        {
+          "$dnanexus_link": "file-G61xbP0433GqX36p8QQxP3PV"
+        },
+        {
+          "$dnanexus_link": "file-G61xf3j433Gz49jf6XjKG4F0"
+        },
+        {
+          "$dnanexus_link": "file-G61xfZ0433Gj2vJ7P8k9ky2Z"
+        },
+        {
+          "$dnanexus_link": "file-G61y4Y8433GvyjJ52Fj5XjY5"
+        }
+      ],
+      "suggestions": [
+        {
+          "name": "001_Reference",
+          "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+          "path": "/annotation/b38/"
+        }
+      ]
     },
     {
       "name": "maf_file",

--- a/src/code.sh
+++ b/src/code.sh
@@ -21,6 +21,10 @@ function annotate_vep_vcf {
 	# find clinvar vcf, remove leading ./
 	clinvar_vcf=$(find ./ -name "clinvar_*.vcf.gz" | sed s'/.\///')
 
+	# find CADD files, remove leading ./
+	cadd_snv=$(find ./ -name "*SNVs.tsv.gz")
+	cadd_indel=$(ifnd ./ -name "*indel.tsv.gz")
+
 	time docker run -v /home/dnanexus:/opt/vep/.vep \
 	ensemblorg/ensembl-vep:release_103.1 \
 	./vep -i /opt/vep/.vep/"${input_vcf}" -o /opt/vep/.vep/"${output_vcf}" \
@@ -29,7 +33,7 @@ function annotate_vep_vcf {
 	--offline \
 	--custom /opt/vep/.vep/"${clinvar_vcf}",ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN \
 	--custom /opt/vep/.vep/"${maf_file_name}",Prev,vcf,exact,0,AC,NS \
-	--plugin CADD,/opt/vep/.vep/whole_genome_SNVs.tsv.gz,/opt/vep/.vep/gnomad.genomes.r3.0.indel.tsv.gz \
+	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
 	--fields "$filter_fields" \
 	--no_stats
 }
@@ -75,6 +79,14 @@ main() {
 	mv "${maf_file_path}" /home/dnanexus/
 	mv "${maf_file_tbi_path}" /home/dnanexus/
 
+	# array inputs end up in subdirectories (i.e. ~/in/array-input/0/), flatten to parent dir
+	find ~/in/vep_plugins -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_plugins
+	find ~/in/vep_refs -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_refs
+	find ~/in/vep_annotation -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_annotation
+
+	# move annotation sources to home
+	mv ~/in/vep_annotation/* /home/dnanexus/
+
 	mark-section "filtering and splitting multiallelics"
 	# retain variants that are: # within ROIs (bed file),
 	#   have at least one allele >0.03 AF, and have DP >99
@@ -101,23 +113,23 @@ main() {
 	
 	# extract vep tarball (input) to /home/dnanexus
 	# --transform used to ensure everything is extracted and not in a sub folder
-	time tar xf "${vep_tarball_path}" -C /home/dnanexus --transform='s/.*\///'
+	# time tar xf "${vep_tarball_path}" -C /home/dnanexus --transform='s/.*\///'
 	
-	# extract annotation tarball to /home/dnanexus
-	time tar xf ~/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
+	# extract vep reference annotation tarball to /home/dnanexus
+	time tar xf /home/dnanexus/in/vep_refs/*.tar.gz -C /home/dnanexus
 
 	# place fasta and indexes for VEP in the annotation folder
-	mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz ~/homo_sapiens_refseq/103_GRCh38/
-	mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai ~/homo_sapiens_refseq/103_GRCh38/
-	mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi ~/homo_sapiens_refseq/103_GRCh38/
+	mv /home/dnanexus/in/vep_refs/*fa.gz* ~/homo_sapiens_refseq/103_GRCh38/
+	# mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz ~/homo_sapiens_refseq/103_GRCh38/
+	# mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai ~/homo_sapiens_refseq/103_GRCh38/
+	# mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi ~/homo_sapiens_refseq/103_GRCh38/
 
 	# place plugins into plugins folder
 	mkdir ~/Plugins
-	mv ~/CADD.pm ~/Plugins/
-	mv ~/plugin_config.txt ~/Plugins/
+	mv ~/in/vep_plugins/* ~/Plugins/
 
-	# load vep docker (asset)
-	docker load -i ~/vep_v103.1_docker.tar.gz
+	# load vep docker
+	docker load -i "$vep_docker_path"
 
 	# will run VEP to annotate against specified transcripts for all,
 	# lymphoid and myeloid gene lists

--- a/src/code.sh
+++ b/src/code.sh
@@ -23,7 +23,7 @@ function annotate_vep_vcf {
 
 	# find CADD files, remove leading ./
 	cadd_snv=$(find ./ -name "*SNVs.tsv.gz")
-	cadd_indel=$(ifnd ./ -name "*indel.tsv.gz")
+	cadd_indel=$(find ./ -name "*indel.tsv.gz")
 
 	time docker run -v /home/dnanexus:/opt/vep/.vep \
 	ensemblorg/ensembl-vep:release_103.1 \
@@ -111,18 +111,11 @@ main() {
 	# vep needs permissions to write to /home/dnanexus
 	chmod a+rwx /home/dnanexus
 	
-	# extract vep tarball (input) to /home/dnanexus
-	# --transform used to ensure everything is extracted and not in a sub folder
-	# time tar xf "${vep_tarball_path}" -C /home/dnanexus --transform='s/.*\///'
-	
 	# extract vep reference annotation tarball to /home/dnanexus
 	time tar xf /home/dnanexus/in/vep_refs/*.tar.gz -C /home/dnanexus
 
 	# place fasta and indexes for VEP in the annotation folder
 	mv /home/dnanexus/in/vep_refs/*fa.gz* ~/homo_sapiens_refseq/103_GRCh38/
-	# mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz ~/homo_sapiens_refseq/103_GRCh38/
-	# mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai ~/homo_sapiens_refseq/103_GRCh38/
-	# mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi ~/homo_sapiens_refseq/103_GRCh38/
 
 	# place plugins into plugins folder
 	mkdir ~/Plugins


### PR DESCRIPTION
- accommodates split vep docker image from annotation sources
  - changed inputs in `dxapp.json` with defaults to same annotation files as currently used
  - updated `code`.sh to handle new inputs
- output shown identical here: https://cuhbioinformatics.atlassian.net/wiki/spaces/URA/pages/2465988609/eggd+vcf+handler+app+for+uranus+-+accommodate+split+annotation+input
- Fixes #19 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcf_handler_for_uranus/24)
<!-- Reviewable:end -->
