### PR TITLE
Add filtering to myeloid panel

### DIFF
--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -352,10 +352,6 @@ def df_report_formatting(panel, vcf_df):
     vcf_df['HGVSp'] = vcf_df['HGVSp'].apply(
         lambda x: regex.sub('p.(', x) + ')' if x else None)
 
-    print(vcf_df)
-    # sys.exit()
-
-
     # add interestingly formatted report text column
     vcf_df['Report_text'] = vcf_df[vcf_df.columns.tolist()].apply(
         lambda x: (

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -154,7 +154,7 @@ def get_field_index(column, field):
 
     Returns: index of given field
     """
-    return column.apply(lambda x: x.split(':').index(field)).to_list()[0]
+    return list(column.apply(lambda x: x.split(':').index(field)))[0]
 
 
 def get_field_value(column, index):
@@ -248,11 +248,11 @@ def df_report_formatting(panel, vcf_df):
     else:
         # mutect2 vcf
         caller = "Mutect2"
-        print(vcf_df['FORMAT'])
+
         # get index of AF in format column, should all be same and have a
         # list with 1 value, used to get AF from the sample column
         af_index = list(set(vcf_df['FORMAT'].apply(
-            lambda x: x.split(':').index('AF')).to_list()
+            lambda x: x.split(':').index('AF'))
         ))
 
         # sense check all AF at same index
@@ -404,7 +404,7 @@ def write_xlsx(fname, vcfs_dict):
     workbook = writer.book
 
     # empty reporting sheet
-    worksheet = writer.sheets['to report']
+    worksheet = workbook.add_worksheet('to report')
 
     for panel_name, vcf_df in vcfs_dict.items():
         # loop over panel dfs, write to sheet & apply formatting

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -390,7 +390,10 @@ def to_report_formatting(col_names):
     Returns: report_df (df): formatted dataframe wth placeholder text as report
         template in specific cells
     """
+    # add the column names for when they paste in reported variants
     report_df = pd.DataFrame(columns=col_names).astype('object')
+
+    # add 12 empty rows as padding for visualise niceness
     report_df = report_df.append(
         [pd.Series([np.nan])] * 12).reindex(col_names, axis=1)
 
@@ -399,17 +402,20 @@ def to_report_formatting(col_names):
         "Insert Size",
     ]
 
-    col6_labels = ["Analysed by", "Date", "Subpanel analysed"]
 
     for label in col1_labels:
+        # set each of the col1 labels as a field in first column
         report_df = report_df.append(
             {report_df.columns[0]: label}, ignore_index=True
         )
 
     report_df.at[12, report_df.columns[3]] = "Sample QC"
 
+    col6_labels = ["Analysed by", "Date", "Subpanel analysed"]
     col6_label_idx = 8
+
     for label in col6_labels:
+        # start at row 8, add each of col6 labels as field in column 6
         report_df.at[col6_label_idx, report_df.columns[5]] = label
         col6_label_idx += 1
 

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -78,7 +78,6 @@ def read_vcf(input_vcf):
         - vcf_df (df): df of variants from vcf
         - vcf_header (list): header from vcf, for writing output (bsvi) vcf
     """
-    print(input_vcf)
     # read in vcf to get header lines
     with open(input_vcf, 'r') as fh:
         vcf_data = fh.readlines()
@@ -252,7 +251,7 @@ def df_report_formatting(panel, vcf_df):
 
     uniq_prev_ns = uniq_prev_ns[0]
 
-    # those not previously seen will have empty string, fill appropriatley to
+    # those not previously seen will have empty string, fill appropriately to
     # display as 0/{total}
     vcf_df['Prev_AC'] = vcf_df['Prev_AC'].apply(
         lambda x: str(0) if x == "" else x)
@@ -386,7 +385,7 @@ def to_report_formatting(col_names):
     """
     Build df of required placeholder text for the to report sheet
 
-    Args: sheet (openpyxl sheet): list of column names from a panel df
+    Args: col_names (list): list of column names from a panel df
 
     Returns: report_df (df): formatted dataframe wth placeholder text as report
         template in specific cells
@@ -419,6 +418,12 @@ def to_report_formatting(col_names):
 def set_column_widths(worksheet, df):
     """
     Sets column widths dyanmically based on cell content
+
+    Args:
+        - worksheet (xlsxwriter sheet object): sheet to modify
+        - df (pd.DataFrame): dataframe for sheet to set widths from
+    Returns:
+        - - worksheet (xlsxwriter sheet object): xlsx sheet with new widths
     """
     for idx, col in enumerate(df):
         # specific formatting for columns with potential very long text
@@ -508,7 +513,7 @@ def write_xlsx(fname, vcfs_dict):
 
     # set specific cells to be bold in to report tab
     for cell in ['A14:A14', 'D14:D14', 'F10:F12']:
-        header_format = workbook.add_format({'bold': True,})
+        header_format = workbook.add_format({'bold': True})
         worksheet.conditional_format(
             cell, {'type': 'no_errors', 'format': header_format}
     )

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -78,6 +78,7 @@ def read_vcf(input_vcf):
         - vcf_df (df): df of variants from vcf
         - vcf_header (list): header from vcf, for writing output (bsvi) vcf
     """
+    print(input_vcf)
     # read in vcf to get header lines
     with open(input_vcf, 'r') as fh:
         vcf_data = fh.readlines()
@@ -506,7 +507,7 @@ def write_xlsx(fname, vcfs_dict):
     worksheet = writer.sheets['to report']
 
     # set specific cells to be bold in to report tab
-    for cell in ['A12:A12', 'D12:D12', 'F8:F10']:
+    for cell in ['A14:A14', 'D14:D14', 'F10:F12']:
         header_format = workbook.add_format({'bold': True,})
         worksheet.conditional_format(
             cell, {'type': 'no_errors', 'format': header_format}
@@ -514,7 +515,7 @@ def write_xlsx(fname, vcfs_dict):
 
     # set dynamic column widths on cell content
     worksheet = set_column_widths(worksheet, report_df)
-
+    worksheet.set_row(0, 12)
 
     for panel_name, vcf_df in vcfs_dict.items():
         # loop over panel dfs, write to sheet & apply formatting
@@ -525,7 +526,7 @@ def write_xlsx(fname, vcfs_dict):
         worksheet.set_column(1, 21, 15)
         worksheet.set_column(22, 22, 70, wrap_format)
         worksheet.set_default_row(100)
-        worksheet.set_row(0, 15)
+        worksheet.set_row(0, 12)
 
         # set dynamic column widths on cell content
         worksheet = set_column_widths(worksheet, vcf_df)

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -503,8 +503,6 @@ def write_xlsx(fname, vcfs_dict):
     workbook = writer.book
 
     # get the column names of a df to write to report sheet
-    # report_worksheet = writer.sheets["to_report"]
-    # worksheet = workbook.add_worksheet('to report')
     header = vcfs_dict[next(iter(vcfs_dict))].columns
     report_df = to_report_formatting(col_names=header)
     report_df.to_excel(writer, sheet_name='to report', index=False)

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -175,6 +175,7 @@ def get_field_value(column, index):
 def filter_common(vcf_df):
     """
     Filters for common variants by prev_count > 50% & synonymous variants
+    EXCEPT in TP53 and
 
     Args: vcf_df (df): df of variants
 
@@ -183,20 +184,20 @@ def filter_common(vcf_df):
         - filter_vcf (df): df of filtered out common variants
     """
     # prev_count formatted as prev_ac/prev_samples (i.e. 45/205)
-    filter_idxs = np.where(
+    filter_idxs = np.where((
         vcf_df['Prev_Count'].apply(
             lambda x: (int(x.split("/")[0]) / int(x.split("/")[1])) > 0.5
         ) | (
             vcf_df['CONSEQ'] == 'synonymous_variant'
-        )
-    )
+        )) & (
+            np.logical_not(vcf_df['GENE'].isin(['TP53', 'GATA2']))
+    ))
 
     # filter df by indixes of filter conditions
     filtered_df = vcf_df.loc[filter_idxs]
     vcf_df = vcf_df.drop(filter_idxs[0])
 
     return vcf_df, filtered_df
-
 
 
 def df_report_formatting(panel, vcf_df):

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -25,13 +25,13 @@ Outputs:
 """
 
 import argparse
-import io
+# import io
 from pathlib import Path
 import re
-import subprocess
+# import subprocess
 import sys
 import pandas as pd
-import xlsxwriter
+# import xlsxwriter
 
 
 def parse_args():
@@ -248,7 +248,7 @@ def df_report_formatting(panel, vcf_df):
     else:
         # mutect2 vcf
         caller = "Mutect2"
-
+        print(vcf_df['FORMAT'])
         # get index of AF in format column, should all be same and have a
         # list with 1 value, used to get AF from the sample column
         af_index = list(set(vcf_df['FORMAT'].apply(
@@ -304,6 +304,10 @@ def df_report_formatting(panel, vcf_df):
     regex = re.compile(r'^[p\.]*')
     vcf_df['HGVSp'] = vcf_df['HGVSp'].apply(
         lambda x: regex.sub('p.(', x) + ')' if x else None)
+
+    print(vcf_df)
+    # sys.exit()
+
 
     # add interestingly formatted report text column
     vcf_df['Report_text'] = vcf_df[vcf_df.columns.tolist()].apply(
@@ -398,6 +402,9 @@ def write_xlsx(fname, vcfs_dict):
     # write excel
     writer = pd.ExcelWriter(excel_fname, engine="xlsxwriter")
     workbook = writer.book
+
+    # empty reporting sheet
+    worksheet = writer.sheets['to report']
 
     for panel_name, vcf_df in vcfs_dict.items():
         # loop over panel dfs, write to sheet & apply formatting

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -242,7 +242,6 @@ def df_report_formatting(panel, vcf_df):
 
     # remove info id from gene
     vcf_df['GENE'] = vcf_df['GENE'].apply(lambda x: x.replace('CSQ=', ''))
-    print('hi')
 
     # calculate Prev_count, first adjust those nor previously seen that have
     # empty strings for prev_ac and prev_ns
@@ -356,7 +355,7 @@ def df_report_formatting(panel, vcf_df):
     vcf_df['Report_text'] = vcf_df[vcf_df.columns.tolist()].apply(
         lambda x: (
             f"{x['GENE']} {x['CONSEQ']} "
-            f"{'in ' + x['EXON'] if x['EXON'] else ''} \n"
+            f"{'in ' + x['EXON'].split('/')[0] if x['EXON'] else ''} \n"
             f"HGVSc: {x['HGVSc'] if x['HGVSc'] else 'None'} \n"
             f"HGVSp: {x['HGVSp'] if x['HGVSp'] else 'None'} \n"
             f"COSMIC ID: {x['COSMIC'] if x['COSMIC'] else 'None'} \n"

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -175,7 +175,7 @@ def get_field_value(column, index):
 def filter_common(vcf_df):
     """
     Filters for common variants by prev_count > 50% & synonymous variants
-    EXCEPT in TP53 and
+    EXCEPT in TP53 and GATA2
 
     Args: vcf_df (df): df of variants
 
@@ -242,7 +242,6 @@ def df_report_formatting(panel, vcf_df):
 
     # remove info id from gene
     vcf_df['GENE'] = vcf_df['GENE'].apply(lambda x: x.replace('CSQ=', ''))
-    print('hi')
 
     # calculate Prev_count, first adjust those nor previously seen that have
     # empty strings for prev_ac and prev_ns

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -391,7 +391,8 @@ def to_report_formatting(col_names):
         template in specific cells
     """
     report_df = pd.DataFrame(columns=col_names).astype('object')
-    report_df = report_df.append([pd.Series([np.nan])] * 12).reindex(col_names, axis=1)
+    report_df = report_df.append(
+        [pd.Series([np.nan])] * 12).reindex(col_names, axis=1)
 
     col1_labels = [
         "Run QC", "250x", "Contamination", "Total reads M", "Fold 80",
@@ -514,7 +515,7 @@ def write_xlsx(fname, vcfs_dict):
         header_format = workbook.add_format({'bold': True})
         worksheet.conditional_format(
             cell, {'type': 'no_errors', 'format': header_format}
-    )
+        )
 
     # set dynamic column widths on cell content
     worksheet = set_column_widths(worksheet, report_df)

--- a/resources/home/dnanexus/vcf_handler.py
+++ b/resources/home/dnanexus/vcf_handler.py
@@ -240,7 +240,7 @@ def df_report_formatting(panel, vcf_df):
     # remove info id from gene
     vcf_df['GENE'] = vcf_df['GENE'].apply(lambda x: x.replace('CSQ=', ''))
 
-    # calculate Prev_count, first adjust those nor previously seen that have
+    # calculate Prev_count, first adjust those not previously seen that have
     # empty strings for prev_ac and prev_ns
 
     # first get total number of samples across all, should return single value

--- a/src/code.sh
+++ b/src/code.sh
@@ -16,7 +16,7 @@ function annotate_vep_vcf {
 
 	input_vcf="$1"
 	output_vcf="$2"
-	
+
 	# fields to filter on
 	# hard coded in function for now, can be made an input but all are the same
 	filter_fields="SYMBOL,VARIANT_CLASS,Consequence,EXON,HGVSc,HGVSp,gnomAD_AF,CADD_PHRED,Existing_variation,ClinVar,ClinVar_CLNDN,ClinVar_CLNSIG,COSMIC,Prev_AC,Prev_NS,Feature"
@@ -62,11 +62,11 @@ function filter_vep_vcf {
 
 	# transcript list should be comma separated, format for passing to VEP
 	transcript_list=$(echo "$transcript_list" | sed 's/[[:space:]]//g')  # remove any whitespace
-	
+
 	# vep filter with match uses regex, therefore we need to change any . to be escaped as \. to
 	# stop it being treat as any single character
-	transcript_list=$(echo "$transcript_list" | sed 's/\./\\./g')  
-	
+	transcript_list=$(echo "$transcript_list" | sed 's/\./\\./g')
+
 	# add required Feature match prepended to every transcript for filtering
 	transcript_list=$(echo "$transcript_list" | sed 's/,/ or Feature match /g')
 	transcript_list="(Feature match ${transcript_list})"
@@ -117,7 +117,7 @@ main() {
 
 	mark-section "filtering pindel VCF"
 	# Filtering of pindel vcf for:
-    # - only indels that intersect with the exons of interest bed file 
+    # - only indels that intersect with the exons of interest bed file
     # - only insertions with length greater than 2. This will remove the 1 bp false positive insertions
 
 	mv /home/dnanexus/in/pindel_vcf/* /home/dnanexus
@@ -130,10 +130,10 @@ main() {
 
 
 	mark-section "annotating and further filtering"
-	
+
 	# vep needs permissions to write to /home/dnanexus
 	chmod a+rwx /home/dnanexus
-	
+
 	# extract vep reference annotation tarball to /home/dnanexus
 	time tar xf /home/dnanexus/in/vep_refs/*.tar.gz -C /home/dnanexus
 


### PR DESCRIPTION
- Adds filtering of myeloid variants that are >50% previous count or synonymous, except for those in TP53 and GATA2, to a separate myeloid_filtered tab to reduce total variants for initial review
- Addition of formatted 'to report' tab to save scientists time creating for each analysis
- Better formatting of output xlsx file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcf_handler_for_uranus/29)
<!-- Reviewable:end -->
